### PR TITLE
Added a script to strip debug data from artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,9 @@ jobs:
                 name: Run tests
                 command: npm test
             - store_test_results:
-                path: transpiled/junit/
+                path: build/junit/
             - store_artifacts:
-                path: transpiled/junit/
+                path: build/junit/
 workflows:
     version: 2
     everything:

--- a/.gitignore
+++ b/.gitignore
@@ -59,4 +59,3 @@ typings/
 
 # truffle build files
 build/
-transpiled/

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,44 @@
         "@types/chai": "4.0.10"
       }
     },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+      "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
+      "dev": true,
+      "requires": {
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.2",
+        "@types/node": "8.5.2"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz",
+      "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
+      "dev": true
+    },
+    "@types/mkdirp": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+      "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.5.2"
+      }
+    },
+    "@types/node": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
+      "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
+      "dev": true
+    },
     "@types/underscore": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.6.tgz",
@@ -641,9 +679,9 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -665,7 +703,7 @@
       "requires": {
         "array-union": "1.0.2",
         "arrify": "1.0.1",
-        "glob": "7.1.1",
+        "glob": "7.1.2",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
@@ -1083,6 +1121,21 @@
         "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
         "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
       }
     },
     "mocha-junit-reporter": {
@@ -1371,7 +1424,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.1"
+        "glob": "7.1.2"
       }
     },
     "run-async": {
@@ -1642,7 +1695,7 @@
         "chalk": "2.3.0",
         "commander": "2.9.0",
         "diff": "3.2.0",
-        "glob": "7.1.1",
+        "glob": "7.1.2",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "1.0.0",
   "description": "Smart Contracts needed to make the ecosystem work",
   "scripts": {
-    "build": "npm run compile && npm run transpile",
-    "transpile": "npm run lint:typescript; tsc",
-    "compile": "npm run lint:solidity; truffle compile",
+    "build": "npm run compile && npm run strip-artifacts",
+    "compile": "npm run build:solidity && npm run build:typescript",
+    "build:typescript": "npm run lint:typescript; tsc",
+    "build:solidity": "npm run lint:solidity; truffle compile",
     "lint": "npm run lint:typescript && npm run lint:solidity",
-    "test": "npm run build && truffle test",
+    "test": "npm run compile && truffle test",
     "lint:typescript": "tslint --project ./",
     "lint:solidity": "solhint contracts/**/*.sol",
+    "strip-artifacts": "node build/scripts/strip-artifacts.js \"build/contracts/**/*.json\" build/artifacts",
     "truffle": "truffle",
     "tsc": "tsc",
     "tslint": "tslint",
@@ -42,6 +44,11 @@
     "tslint": "^5.8.0",
     "typescript": "^2.6.2",
     "web3-typescript-typings": "^0.7.2",
-    "zeppelin-solidity": "^1.4.0"
+    "zeppelin-solidity": "^1.4.0",
+    "@types/glob": "^5.0.34",
+    "@types/mkdirp": "^0.5.2",
+    "@types/node": "^8.5.2",
+    "glob": "^7.1.2",
+    "mkdirp": "^0.5.1"
   }
 }

--- a/scripts/strip-artifacts.ts
+++ b/scripts/strip-artifacts.ts
@@ -1,0 +1,59 @@
+import * as fs from "fs";
+import * as glob from "glob";
+import * as mkdirp from "mkdirp";
+import * as path from "path";
+
+/*
+ * Artifacts in the newest version of Truffle have a lot of data we don't need nor want in our library
+ * We're striping it to not leak and also have easier time managing JSONs
+ * The only things we're leaving are:
+ * - contractName
+ * - abi
+ * - bytecode (for deploying)
+ * - deployedBytecode (for source code confirming)
+ * - networks
+ */
+
+const JSON_WHITESPACE = 4;
+
+function strip(filePath: string, outPath: string) {
+  const data = JSON.parse(fs.readFileSync(filePath) as any);
+  /* tslint:disable object-literal-sort-keys */
+  const filtered = {
+    contractName: data.contractName,
+    bytecode: data.bytecode,
+    deployedBytecode: data.deployedBytecode,
+    abi: data.abi,
+    networks: data.networks,
+  };
+  /* tslint:enable object-literal-sort-keys */
+  fs.writeFileSync(outPath, JSON.stringify(filtered, null, JSON_WHITESPACE));
+  console.log("Written: " + outPath);
+}
+
+if (process.argv.length !== 4) {
+  console.error("Usage: " + process.argv[0] + " json_files_glob out_dir");
+  process.exit();
+}
+
+const FILES_GLOB = process.argv[2];
+const OUT_DIR = process.argv[3];
+
+// Ensure out directory exists
+mkdirp.sync(OUT_DIR);
+
+glob(FILES_GLOB, (err, files) => {
+  if (err) {
+    console.error("Failed to parse glob", err);
+    return process.exit(1);
+  }
+
+  files.forEach((filePath) => {
+    const filename = path.basename(filePath);
+    const outPath = path.posix.format({
+      base: filename,
+      dir: OUT_DIR,
+    } as any);
+    strip(filePath, outPath);
+  });
+});

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,14 +1,14 @@
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
-  migrations_directory: "transpiled/migrations",
-  test_directory: "transpiled/test",
+  migrations_directory: "build/migrations",
+  test_directory: "build/test",
   mocha: {
     reporter: 'mocha-multi-reporters',
     reporterOptions: {
       reporterEnabled: "mocha-junit-reporter, spec",
       mochaJunitReporterReporterOptions: {
-        mochaFile: './transpiled/junit/junit.xml'
+        mochaFile: './build/junit/junit.xml'
       }
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./transpiled/",                        /* Redirect output structure to the directory. */
+    "outDir": "./build/",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
@@ -56,6 +56,7 @@
     "./test/**/*.ts",
     "./utils/**/*.ts",
     "./migrations/**/*.ts",
+    "./scripts/**.ts",
     "./node_modules/web3-typescript-typings/index.d.ts"
   ]
 }


### PR DESCRIPTION
Debug data in truffle JSONs takes quite a lot of space, and are
hard to read by a human. By stripping it to minimum not only are
we decreasing the size for the user, but also removing attack vectors