### PR TITLE
Remove public access to mappings to structs

### DIFF
--- a/contracts/AddressRegistry.sol
+++ b/contracts/AddressRegistry.sol
@@ -24,7 +24,7 @@ contract AddressRegistry {
 
     struct Listing {
         uint applicationExpiry; // Expiration date of apply stage
-        bool isWhitelisted;       // Indicates registry status
+        bool isWhitelisted;     // Indicates registry status
         address owner;          // Owner of listing
         uint unstakedDeposit;   // Number of tokens in the listing not locked in a challenge
         uint challengeID;       // Corresponds to a PollID in PLCRVoting

--- a/contracts/AddressRegistry.sol
+++ b/contracts/AddressRegistry.sol
@@ -11,20 +11,20 @@ contract AddressRegistry {
     // EVENTS
     // ------
 
-    event Application(address listingAddress, uint deposit, string data);
-    event ChallengeInitiated(address listingAddress, uint deposit, uint pollID, string data);
-    event Deposit(address listingAddress, uint added, uint newTotal);
-    event Withdrawal(address listingAddress, uint withdrew, uint newTotal);
-    event NewListingWhitelisted(address listingAddress);
-    event ApplicationRemoved(address listingAddress);
-    event ListingRemoved(address listingAddress);
-    event ChallengeFailed(uint challengeID);
-    event ChallengeSucceeded(uint challengeID);
-    event RewardClaimed(address voter, uint challengeID, uint reward);
+    event Application(address indexed listingAddress, uint deposit, string data);
+    event ChallengeInitiated(address indexed listingAddress, uint deposit, uint indexed pollID, string data);
+    event Deposit(address indexed listingAddress, uint added, uint newTotal);
+    event Withdrawal(address indexed listingAddress, uint withdrew, uint newTotal);
+    event NewListingWhitelisted(address indexed listingAddress);
+    event ApplicationRemoved(address indexed listingAddress);
+    event ListingRemoved(address indexed listingAddress);
+    event ChallengeFailed(uint indexed challengeID);
+    event ChallengeSucceeded(uint indexed challengeID);
+    event RewardClaimed(address indexed voter, uint indexed challengeID, uint reward);
 
     struct Listing {
         uint applicationExpiry; // Expiration date of apply stage
-        bool whitelisted;       // Indicates registry status
+        bool isWhitelisted;       // Indicates registry status
         address owner;          // Owner of listing
         uint unstakedDeposit;   // Number of tokens in the listing not locked in a challenge
         uint challengeID;       // Corresponds to a PollID in PLCRVoting
@@ -40,10 +40,10 @@ contract AddressRegistry {
     }
 
     // Maps challengeIDs to associated challenge data
-    mapping(uint => Challenge) public challenges;
+    mapping(uint => Challenge) internal challenges;
 
     // Maps addresses to associated listing data
-    mapping(address => Listing) public listings;
+    mapping(address => Listing) internal listings;
 
     // Global Variables
     EIP20 public token;
@@ -83,7 +83,7 @@ contract AddressRegistry {
     @param _data        Extra data relevant to the application. Think IPFS hashes.
     */
     function apply(address _listingAddress, uint _amount, string _data) external {
-        require(!isWhitelisted(_listingAddress));
+        require(!getListingIsWhitelisted(_listingAddress));
         require(!appWasMade(_listingAddress));
         require(_amount >= parameterizer.get("minDeposit"));
         require(block.timestamp + parameterizer.get("applyStageLen") > block.timestamp); // avoid overflow  
@@ -143,7 +143,7 @@ contract AddressRegistry {
         Listing storage listing = listings[_listingAddress];
 
         require(listing.owner == msg.sender);
-        require(isWhitelisted(_listingAddress));
+        require(getListingIsWhitelisted(_listingAddress));
 
         // Cannot exit during ongoing challenge
         require(listing.challengeID == NO_CHALLENGE || challenges[listing.challengeID].resolved);
@@ -170,7 +170,7 @@ contract AddressRegistry {
         uint deposit = parameterizer.get("minDeposit");
 
         // Listing must be in apply stage or already on the whitelist
-        require(appWasMade(_listingAddress) || listing.whitelisted);
+        require(appWasMade(_listingAddress) || listing.isWhitelisted);
         // Prevent multiple challenges
         require(listing.challengeID == NO_CHALLENGE || challenges[listing.challengeID].resolved);
 
@@ -259,6 +259,51 @@ contract AddressRegistry {
     // GETTERS:
     // --------
 
+    // --------
+    // Basic Listing Getters
+    // --------
+    function getListingApplicationExpiry(address _listingAddress) public view returns (uint) {
+      return listings[_listingAddress].applicationExpiry;
+    }
+
+    function getListingOwner(address _listingAddress) public view returns (address) {
+      return listings[_listingAddress].owner;
+    }
+
+    function getListingIsWhitelisted(address _listingAddress) public view returns (bool) {
+      return listings[_listingAddress].isWhitelisted;
+    }
+
+    function getListingUnstakedDeposit(address _listingAddress) public view returns (uint) {
+      return listings[_listingAddress].unstakedDeposit;
+    }
+
+    function getListingChallengeID(address _listingAddress) public view returns (uint) {
+      return listings[_listingAddress].challengeID;
+    }
+
+    // --------
+    // Basic Challenge Getters
+    // --------
+    function getChallengeRewardPool(uint _challengeID) public view returns (uint) {
+      return challenges[_challengeID].rewardPool;
+    }
+
+    function getChallengeChallenger(uint _challengeID) public view returns (address) {
+      return challenges[_challengeID].challenger;
+    }
+
+    function getChallengeResolved(uint _challengeID) public view returns (bool) {
+      return challenges[_challengeID].resolved;
+    }
+
+    function getChallengeStake(uint _challengeID) public view returns (uint) {
+      return challenges[_challengeID].stake;
+    }
+
+    function getChallengeTotalTokens(uint _challengeID) public view returns (uint) {
+      return challenges[_challengeID].totalTokens;
+    }
     /**
     @dev                Calculates the provided voter's token reward for the given poll.
     @param _voter       The address of the voter whose reward balance is to be returned
@@ -275,7 +320,7 @@ contract AddressRegistry {
     }
 
     /**
-    @dev                Determines whether the given listingAddress be whitelisted.
+    @dev                Determines whether the given listingAddress be isWhitelist.
     @param _listingAddress The _listingAddress whose status is to be examined
     */
     function canBeWhitelisted(address _listingAddress) view public returns (bool) {
@@ -288,19 +333,11 @@ contract AddressRegistry {
         if (
             appWasMade(_listingAddress) &&
             listings[_listingAddress].applicationExpiry < now &&
-            !isWhitelisted(_listingAddress) &&
+            !getListingIsWhitelisted(_listingAddress) &&
             (challengeID == NO_CHALLENGE || challenges[challengeID].resolved == true)
         ) { return true; }
 
         return false;
-    }
-
-    /**
-    @dev                Returns true if the provided listingAddress is whitelisted
-    @param _listingAddress The listingAddress whose status is to be examined
-    */
-    function isWhitelisted(address _listingAddress) view public returns (bool) {
-        return listings[_listingAddress].whitelisted;
     }
 
     /**
@@ -375,7 +412,7 @@ contract AddressRegistry {
         uint reward = determineReward(challengeID);
 
         // Records whether the listingAddress is a listing or an application
-        bool wasWhitelisted = isWhitelisted(_listingAddress);
+        bool wasWhitelisted = getListingIsWhitelisted(_listingAddress);
 
         
         if (voting.isPassed(challengeID)) { // Case: challenge failed
@@ -411,10 +448,10 @@ contract AddressRegistry {
     @dev                Called by updateStatus() if the applicationExpiry date passed without a
                         challenge being made. Called by resolveChallenge() if an
                         application/listing beat a challenge.
-    @param _listingAddress The listingAddress of an application/listing to be whitelisted
+    @param _listingAddress The listingAddress of an application/listing to be isWhitelist
     */
     function whitelistApplication(address _listingAddress) private {
-        listings[_listingAddress].whitelisted = true;
+        listings[_listingAddress].isWhitelisted = true;
     }
 
     /**

--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -41,7 +41,32 @@ contract PLCRVoting {
     uint constant public INITIAL_POLL_NONCE = 0;
     uint public pollNonce;
 
-    mapping(uint => Poll) public pollMap; // maps pollID to Poll struct
+    mapping(uint => Poll) internal pollMap; // maps pollID to Poll struct
+
+    // --------
+    // Basic Poll Getters
+    // --------
+
+    function getPollCommitEndDate(uint _pollID) public view returns (uint) {
+      return pollMap[_pollID].commitEndDate;
+    }
+
+    function getPollRevealEndDate(uint _pollID) public view returns (uint) {
+      return pollMap[_pollID].revealEndDate;
+    }
+
+    function getPollVoteQuorum(uint _pollID) public view returns (uint) {
+      return pollMap[_pollID].voteQuorum;
+    }
+
+    function getPollVotesFor(uint _pollID) public view returns (uint) {
+      return pollMap[_pollID].votesFor;
+    }
+
+    function getPollVotesAgainst(uint _pollID) public view returns (uint) {
+      return pollMap[_pollID].votesAgainst;
+    }
+    
     mapping(address => uint) public voteTokenBalance; // maps user's address to voteToken balance
 
     mapping(address => DLL.Data) dllMap;

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -9,8 +9,8 @@ contract Parameterizer {
   // EVENTS
   // ------
 
-  event _ReparameterizationProposal(address proposer, string name, uint value, bytes32 propID);
-  event _NewChallenge(address challenger, bytes32 propID, uint pollID);
+  event ReparameterizationProposal(address indexed proposer, bytes32 indexed paramNameHash, string name, uint value, bytes32 propID);
+  event NewChallenge(address indexed challenger, bytes32 indexed propID, uint pollID);
 
 
   // ------
@@ -43,10 +43,10 @@ contract Parameterizer {
   mapping(bytes32 => uint) public params;
 
   // maps challengeIDs to associated challenge data
-  mapping(uint => Challenge) public challenges;
- 
+  mapping(uint => Challenge) internal challenges;
+
   // maps pollIDs to intended data change if poll passes
-  mapping(bytes32 => ParamProposal) public proposals; 
+  mapping(bytes32 => ParamProposal) internal proposals; 
 
   // Global Variables
   EIP20 public token;
@@ -138,7 +138,7 @@ contract Parameterizer {
       value: _value
     });
 
-    _ReparameterizationProposal(msg.sender, _name, _value, propID);
+    ReparameterizationProposal(msg.sender, keccak256(_name), _name, _value, propID);
     return propID;
   }
 
@@ -171,7 +171,7 @@ contract Parameterizer {
 
     proposals[_propID].challengeID = pollID;       // update listing to store most recent challenge
 
-    _NewChallenge(msg.sender, _propID, pollID);
+    NewChallenge(msg.sender, _propID, pollID);
     return pollID;
   }
 
@@ -223,6 +223,65 @@ contract Parameterizer {
   // GETTERS
   // --------
 
+  // --------
+  // Proposal Mapping
+  // --------
+
+  function getPropAppExpiry(bytes32 _propID) public view returns (uint) {
+    return proposals[_propID].appExpiry;
+  }
+
+  function getPropChallengeID(bytes32 _propID) public view returns (uint) {
+    return proposals[_propID].challengeID;
+  }
+
+  function getPropDeposit(bytes32 _propID) public view returns (uint) {
+    return proposals[_propID].deposit;
+  }
+
+  function getPropName(bytes32 _propID) public view returns (string) {
+    return proposals[_propID].name;
+  }
+
+  function getPropOwner(bytes32 _propID) public view returns (address) {
+    return proposals[_propID].owner;
+  }
+
+  function getPropProcessBy(bytes32 _propID) public view returns (uint) {
+    return proposals[_propID].processBy;
+  }
+
+  function getPropValue(bytes32 _propID) public view returns (uint) {
+    return proposals[_propID].value;
+  }
+
+  // --------
+  // Challenge Mapping
+  // --------
+
+  function getChallengeRewardPool(uint _challengeID) public view returns (uint) {
+    return challenges[_challengeID].rewardPool;
+  }
+ 
+  function getChallengeChallenger(uint _challengeID) public view returns (address) {
+    return challenges[_challengeID].challenger;
+  }
+
+  function getChallengeResolved(uint _challengeID) public view returns (bool) {
+    return challenges[_challengeID].resolved;
+  }
+
+  function getChallengeStake(uint _challengeID) public view returns (uint) {
+    return challenges[_challengeID].stake;
+  }
+  
+  function getChallengeWinningTokens(uint _challengeID) public view returns (uint) {
+    return challenges[_challengeID].winningTokens;
+  }
+
+  // --------
+  // Computed Values
+  // --------
   /**
   @dev                Calculates the provided voter's token reward for the given poll.
   @param _voter       The address of the voter whose reward balance is to be returned

--- a/test/parameterizer/canBeSet.ts
+++ b/test/parameterizer/canBeSet.ts
@@ -15,18 +15,33 @@ contract("Parameterizer", (accounts: string[]) => {
     });
 
     it("should return true if a proposal passed its application stage with no challenge", async () => {
-      const propID = await utils.proposeReparamAndGetPropID("voteQuorum", "51", parameterizer, proposer);
+      const propID = await utils.proposeReparamAndGetPropID(
+        "voteQuorum",
+        utils.toBaseTenBigNumber(51),
+        parameterizer,
+        proposer,
+      );
       await utils.advanceEvmTime(utils.paramConfig.pApplyStageLength + 1);
       const result = await parameterizer.canBeSet(propID);
       expect(result).to.be.true();
     });
     it("should return false if a proposal is still in its application stage with no challenge", async () => {
-      const propID = await utils.proposeReparamAndGetPropID("pRevealStageLength", "500", parameterizer, proposer);
+      const propID = await utils.proposeReparamAndGetPropID(
+        "pRevealStageLength",
+        utils.toBaseTenBigNumber(500),
+        parameterizer,
+        proposer,
+      );
       const result = await parameterizer.canBeSet(propID);
       expect(result).to.be.false();
     });
     it("should expect false immediately after proposal, and true once enough time has passed", async () => {
-      const propID = await utils.proposeReparamAndGetPropID("dispensationPct", "58", parameterizer, proposer);
+      const propID = await utils.proposeReparamAndGetPropID(
+        "dispensationPct",
+        utils.toBaseTenBigNumber(58),
+        parameterizer,
+        proposer,
+      );
 
       const betterBeFalse = await parameterizer.canBeSet(propID);
       expect(betterBeFalse).to.be.false();

--- a/test/parameterizer/challengeCanBeResolved.ts
+++ b/test/parameterizer/challengeCanBeResolved.ts
@@ -15,7 +15,12 @@ contract("Parameterizer", (accounts) => {
     });
 
     it("should be true if a challenge is ready to be resolved", async () => {
-      const propID = await utils.proposeReparamAndGetPropID("voteQuorum", "51", parameterizer, proposer);
+      const propID = await utils.proposeReparamAndGetPropID(
+        "voteQuorum",
+        utils.toBaseTenBigNumber(51),
+        parameterizer,
+        proposer,
+    );
 
       await parameterizer.challengeReparameterization(propID, { from: challenger});
       await utils.advanceEvmTime(utils.paramConfig.pCommitStageLength);
@@ -26,7 +31,11 @@ contract("Parameterizer", (accounts) => {
     });
 
     it("should be false if a challenge is not ready to be resolved", async () => {
-      const propID = await utils.proposeReparamAndGetPropID("voteQuorum", "59", parameterizer, proposer);
+      const propID = await utils.proposeReparamAndGetPropID(
+        "voteQuorum",
+        utils.toBaseTenBigNumber(59),
+        parameterizer,
+        proposer);
 
       await parameterizer.challengeReparameterization(propID, { from: challenger });
       await utils.advanceEvmTime(utils.paramConfig.pCommitStageLength);

--- a/test/parameterizer/processProposal.ts
+++ b/test/parameterizer/processProposal.ts
@@ -44,7 +44,6 @@ contract("Parameterizer", (accounts) => {
 
       const { propID } = receipt.logs[0].args;
       const processBy = await parameterizer.getPropProcessBy(propID);
-      // const processBy = paramProp[5];
       await utils.advanceEvmTime(processBy.toNumber() + 1);
 
       await parameterizer.processProposal(propID);
@@ -75,7 +74,6 @@ contract("Parameterizer", (accounts) => {
       await voting.revealVote(pollID, "0", "420", { from: voter });
 
       const processBy = await parameterizer.getPropProcessBy(propID);
-      // const processBy = paramProp[5];
       await utils.advanceEvmTime(processBy.toNumber() + 1);
 
       await parameterizer.processProposal(propID);

--- a/test/parameterizer/processProposal.ts
+++ b/test/parameterizer/processProposal.ts
@@ -43,8 +43,8 @@ contract("Parameterizer", (accounts) => {
       const receipt = await parameterizer.proposeReparameterization("voteQuorum", "69", { from: proposer });
 
       const { propID } = receipt.logs[0].args;
-      const paramProp = await parameterizer.proposals(propID);
-      const processBy = paramProp[5];
+      const processBy = await parameterizer.getPropProcessBy(propID);
+      // const processBy = paramProp[5];
       await utils.advanceEvmTime(processBy.toNumber() + 1);
 
       await parameterizer.processProposal(propID);
@@ -74,8 +74,8 @@ contract("Parameterizer", (accounts) => {
 
       await voting.revealVote(pollID, "0", "420", { from: voter });
 
-      const paramProp = await parameterizer.proposals(propID);
-      const processBy = paramProp[5];
+      const processBy = await parameterizer.getPropProcessBy(propID);
+      // const processBy = paramProp[5];
       await utils.advanceEvmTime(processBy.toNumber() + 1);
 
       await parameterizer.processProposal(propID);

--- a/test/parameterizer/propExists.ts
+++ b/test/parameterizer/propExists.ts
@@ -15,7 +15,12 @@ contract("Parameterizer", (accounts) => {
     });
 
     it("should true if a proposal exists for the provided propID", async () => {
-      const propID = await utils.proposeReparamAndGetPropID("voteQuorum", "51", parameterizer, proposer);
+      const propID = await utils.proposeReparamAndGetPropID(
+        "voteQuorum",
+        utils.toBaseTenBigNumber(51),
+        parameterizer,
+        proposer,
+      );
       const result = await parameterizer.propExists(propID);
       expect(result).to.be.true("should have been true cause I literally just made the proposal");
     });

--- a/test/parameterizer/proposeReparameterization.ts
+++ b/test/parameterizer/proposeReparameterization.ts
@@ -27,9 +27,9 @@ contract("Parameterizer", (accounts) => {
       const receipt = await parameterizer.proposeReparameterization("voteQuorum", "51", { from: proposer });
 
       const propID = utils.getReceiptValue(receipt, "propID");
-      const paramProposal = await parameterizer.proposals(propID);
+      const propValue = await parameterizer.getPropValue(propID);
 
-      expect(paramProposal[6]).to.be.bignumber.equal(
+      expect(propValue).to.be.bignumber.equal(
         "51",
         "The reparameterization proposal was not created, or not created correctly.",
       );

--- a/test/registry/appWasMade.ts
+++ b/test/registry/appWasMade.ts
@@ -32,7 +32,7 @@ contract("Registry", (accounts) => {
       // Reveal stage complete, update status (whitelist it)
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await registry.updateStatus(listing2, { from: applicant });
-      const isWhitelisted = await registry.isWhitelisted(listing2);
+      const isWhitelisted = await registry.getListingIsWhitelisted(listing2);
       expect(isWhitelisted).to.be.true("should have been whitelisted");
       const resultThree = await registry.appWasMade(listing2);
       expect(resultThree).to.be.true("should have returned true because its whitelisted");

--- a/test/registry/apply.ts
+++ b/test/registry/apply.ts
@@ -20,7 +20,10 @@ contract("AddressRegistry", (accounts) => {
       await registry.apply(listing1, utils.paramConfig.minDeposit, "", {from: applicant });
       // get the struct in the mapping
       // TODO: getting structs is undefined behavior, convert this to multiple gets
-      const [applicationExpiry, whitelisted, owner, unstakedDeposit] = await registry.listings(listing1);
+      const applicationExpiry = await registry.getListingApplicationExpiry(listing1);
+      const whitelisted = await registry.getListingIsWhitelisted(listing1);
+      const owner = await registry.getListingOwner(listing1);
+      const unstakedDeposit = await registry.getListingUnstakedDeposit(listing1);
       // check that Application is initialized correctly
       expect(applicationExpiry).to.be.bignumber.gt(0, "challenge time < now");
       expect(whitelisted).to.be.false("whitelisted != false");
@@ -40,7 +43,7 @@ contract("AddressRegistry", (accounts) => {
         await registry.apply(listing1, utils.paramConfig.minDeposit, "", {from: applicant });
         await utils.advanceEvmTime(utils.paramConfig.applyStageLength + 1);
         await registry.updateStatus(listing1);
-        const result = await registry.isWhitelisted.call(listing1);
+        const result = await registry.getListingIsWhitelisted(listing1);
         expect(result).to.be.true("listing didn't get whitelisted");
       },
     );

--- a/test/registry/challenge.ts
+++ b/test/registry/challenge.ts
@@ -40,7 +40,7 @@ contract("Registry", (accounts) => {
       await utils.advanceEvmTime(utils.paramConfig.commitStageLength + utils.paramConfig.revealStageLength + 1);
       await registry.updateStatus(listing3);
 
-      const isWhitelisted = await registry.isWhitelisted.call(listing3);
+      const isWhitelisted = await registry.getListingIsWhitelisted.call(listing3);
       expect(isWhitelisted).to.be.false("An application which should have failed succeeded");
 
       const challengerFinalBalance = await token.balanceOf.call(challenger);
@@ -61,7 +61,7 @@ contract("Registry", (accounts) => {
       await utils.advanceEvmTime(utils.paramConfig.commitStageLength + utils.paramConfig.revealStageLength + 1);
       await registry.updateStatus(listing4);
 
-      const isWhitelisted = await registry.isWhitelisted.call(listing4);
+      const isWhitelisted = await registry.getListingIsWhitelisted.call(listing4);
       expect(isWhitelisted).to.be.false("An application which should have failed succeeded");
 
       const challengerFinalBalance = await token.balanceOf.call(challenger);
@@ -84,12 +84,12 @@ contract("Registry", (accounts) => {
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await registry.updateStatus(listing5);
 
-      const isWhitelisted = await registry.isWhitelisted(listing5);
+      const isWhitelisted = await registry.getListingIsWhitelisted(listing5);
       expect(isWhitelisted).to.be.true(
         "An application which should have succeeded failed",
       );
 
-      const unstakedDeposit = await utils.getUnstakedDeposit(listing5, registry);
+      const unstakedDeposit = await registry.getListingUnstakedDeposit(listing5);
       const expectedUnstakedDeposit =
         minDeposit.add(minDeposit.mul(utils.paramConfig.dispensationPct).div(100));
 
@@ -110,10 +110,10 @@ contract("Registry", (accounts) => {
       await utils.advanceEvmTime(utils.paramConfig.revealStageLength + 1);
       await registry.updateStatus(listing6);
 
-      const isWhitelisted = await registry.isWhitelisted(listing6);
+      const isWhitelisted = await registry.getListingIsWhitelisted(listing6);
       expect(isWhitelisted).to.be.true("An application which should have succeeded failed");
 
-      const unstakedDeposit = await utils.getUnstakedDeposit(listing6, registry);
+      const unstakedDeposit = await registry.getListingUnstakedDeposit(listing6);
       const expectedUnstakedDeposit = minDeposit.add(
         minDeposit.mul(utils.toBaseTenBigNumber(utils.paramConfig.dispensationPct).div(utils.toBaseTenBigNumber(100))));
       expect(unstakedDeposit).to.be.bignumber.equal(expectedUnstakedDeposit,
@@ -146,7 +146,7 @@ contract("Registry", (accounts) => {
 
       expect(applicantStartingBal).to.be.bignumber.equal(applicantFinalBal, "Tokens were not returned to applicant");
 
-      const isWhitelisted = await registry.isWhitelisted(listing7);
+      const isWhitelisted = await registry.getListingIsWhitelisted(listing7);
       expect(isWhitelisted).to.be.false("Listing was not removed");
     });
   });

--- a/test/registry/deposit.ts
+++ b/test/registry/deposit.ts
@@ -26,7 +26,7 @@ contract("Registry", (accounts) => {
       await utils.addToWhitelist(listing13, minDeposit, applicant, registry);
       await registry.deposit(listing13, incAmount, { from: applicant });
 
-      const unstakedDeposit = await utils.getUnstakedDeposit(listing13, registry);
+      const unstakedDeposit = await registry.getListingUnstakedDeposit(listing13);
       const expectedAmount = incAmount.add(minDeposit);
       expect(unstakedDeposit).to.be.bignumber.equal(expectedAmount,
         "Unstaked deposit should be equal to the sum of the original + increase amount",
@@ -38,7 +38,7 @@ contract("Registry", (accounts) => {
 
       await registry.deposit(listing14, incAmount, { from: applicant });
 
-      const unstakedDeposit = await utils.getUnstakedDeposit(listing14, registry);
+      const unstakedDeposit = await registry.getListingUnstakedDeposit(listing14);
       const expectedAmount = incAmount.add(minDeposit);
       expect(unstakedDeposit).to.be.bignumber.equal(expectedAmount,
         "Deposit should have increased for pending application");
@@ -46,13 +46,13 @@ contract("Registry", (accounts) => {
 
     it("should increase deposit for a whitelisted, challenged listing", async () => {
       await utils.addToWhitelist(listing15, minDeposit, applicant, registry);
-      const originalDeposit = await utils.getUnstakedDeposit(listing15, registry);
+      const originalDeposit = await registry.getListingUnstakedDeposit(listing15);
 
       // challenge, then increase deposit
       await registry.challenge(listing15, "", { from: challenger });
       await registry.deposit(listing15, incAmount, { from: applicant });
 
-      const afterIncDeposit = await utils.getUnstakedDeposit(listing15, registry);
+      const afterIncDeposit = await registry.getListingUnstakedDeposit(listing15);
 
       const expectedAmount = originalDeposit.add(incAmount).sub(minDeposit);
 

--- a/test/registry/exit.ts
+++ b/test/registry/exit.ts
@@ -27,12 +27,12 @@ contract("Registry", (accounts) => {
 
       await utils.addToWhitelist(listing17, utils.paramConfig.minDeposit, applicant, registry);
 
-      const isWhitelisted = await registry.isWhitelisted(listing17);
+      const isWhitelisted = await registry.getListingIsWhitelisted(listing17);
       expect(isWhitelisted).to.be.true("the listing was not added to the registry");
 
       await registry.exitListing(listing17, { from: applicant });
 
-      const isWhitelistedAfterExit = await registry.isWhitelisted(listing17);
+      const isWhitelistedAfterExit = await registry.getListingIsWhitelisted(listing17);
       expect(isWhitelistedAfterExit).to.be.false("the listing was not removed on exit");
 
       const finalApplicantTokenHoldings = await token.balanceOf(applicant);
@@ -46,14 +46,14 @@ contract("Registry", (accounts) => {
 
       await utils.addToWhitelist(listing18, utils.paramConfig.minDeposit, applicant, registry);
 
-      const isWhitelisted = await registry.isWhitelisted(listing18);
+      const isWhitelisted = await registry.getListingIsWhitelisted(listing18);
       expect(isWhitelisted).to.be.true("the listing was not added to the registry");
 
       await registry.challenge(listing18, "", { from: challenger });
       await expect(registry.exitListing(listing18, { from: applicant }))
       .to.eventually.be.rejectedWith(REVERTED, "exit succeeded when it should have failed");
 
-      const isWhitelistedAfterExit = await registry.isWhitelisted(listing18);
+      const isWhitelistedAfterExit = await registry.getListingIsWhitelisted(listing18);
       expect(isWhitelistedAfterExit).to.be.true(
         "the listing was able to exit while a challenge was active",
       );
@@ -73,7 +73,7 @@ contract("Registry", (accounts) => {
 
       await expect(registry.exitListing(listing18, { from: voter }))
       .to.eventually.be.rejectedWith(REVERTED, "exit succeeded when it should have failed");
-      const isWhitelistedAfterExit = await registry.isWhitelisted(listing18);
+      const isWhitelistedAfterExit = await registry.getListingIsWhitelisted(listing18);
       expect(isWhitelistedAfterExit).to.be.true(
         "the listing was exited by someone other than its owner",
       );

--- a/test/registry/isWhitelisted.ts
+++ b/test/registry/isWhitelisted.ts
@@ -15,13 +15,13 @@ contract("Registry", (accounts) => {
     });
 
     it("should verify a listing is not in the whitelist", async () => {
-      const result = await registry.isWhitelisted(listing19);
+      const result = await registry.getListingIsWhitelisted(listing19);
       expect(result).to.be.false("Listing should not be whitelisted");
     });
 
     it("should verify a listing is in the whitelist", async () => {
       await utils.addToWhitelist(listing19, utils.paramConfig.minDeposit, applicant, registry);
-      const result = await registry.isWhitelisted.call(listing19);
+      const result = await registry.getListingIsWhitelisted.call(listing19);
       expect(result).to.be.true("Listing should have been whitelisted");
     });
   });

--- a/test/registry/updateStatus.ts
+++ b/test/registry/updateStatus.ts
@@ -26,7 +26,7 @@ contract("Registry", (accounts) => {
       // note: this function calls registry.updateStatus at the end
       await utils.addToWhitelist(listing21, minDeposit, applicant, registry);
 
-      const result = await registry.isWhitelisted(listing21);
+      const result = await registry.getListingIsWhitelisted(listing21);
       expect(result).to.be.true("Listing should have been whitelisted");
     });
 
@@ -53,7 +53,7 @@ contract("Registry", (accounts) => {
       await utils.advanceEvmTime(plcrComplete);
 
       await registry.updateStatus(listing24);
-      const result = await registry.isWhitelisted(listing24);
+      const result = await registry.getListingIsWhitelisted(listing24);
       expect(result).to.be.false("Listing should not have been whitelisted");
     });
 
@@ -65,11 +65,11 @@ contract("Registry", (accounts) => {
     it("should not be possible to add a listing to the whitelist just " +
       "by calling updateStatus after it has been previously removed", async () => {
       await utils.addToWhitelist(listing26, minDeposit, applicant, registry);
-      const resultOne = await registry.isWhitelisted(listing26);
+      const resultOne = await registry.getListingIsWhitelisted(listing26);
       expect(resultOne).to.be.true("Listing should have been whitelisted");
 
       await registry.exitListing(listing26, { from: applicant });
-      const resultTwo = await registry.isWhitelisted(listing26);
+      const resultTwo = await registry.getListingIsWhitelisted(listing26);
       expect(resultTwo).to.be.false("Listing should not be in the whitelist");
 
       await expect(registry.updateStatus(listing26, { from: applicant }))

--- a/test/registry/userStories.ts
+++ b/test/registry/userStories.ts
@@ -30,7 +30,7 @@ contract("Registry", (accounts) => {
       await registry.updateStatus(listing27);
 
       // should not have been added to whitelist
-      const result = await registry.isWhitelisted(listing27);
+      const result = await registry.getListingIsWhitelisted(listing27);
       expect(result).to.be.false("listing should not be whitelisted");
     });
 
@@ -76,7 +76,7 @@ contract("Registry", (accounts) => {
 
       // Add to whitelist
       await registry.updateStatus(listing28);
-      const result = await registry.isWhitelisted(listing28);
+      const result = await registry.getListingIsWhitelisted(listing28);
       expect(result).to.be.true("Listing should be whitelisted");
     });
   });

--- a/test/registry/withdraw.ts
+++ b/test/registry/withdraw.ts
@@ -23,12 +23,12 @@ contract("Registry", (accounts) => {
       const errMsg = "applicant was able to withdraw tokens";
 
       await utils.addToWhitelist(dontChallengeListing, minDeposit, applicant, registry);
-      const origDeposit = await utils.getUnstakedDeposit(dontChallengeListing, registry);
+      const origDeposit = await registry.getListingUnstakedDeposit(dontChallengeListing);
 
       await expect(registry.withdraw(dontChallengeListing, withdrawAmount, { from: applicant }))
       .to.eventually.be.rejectedWith(REVERTED);
 
-      const afterWithdrawDeposit = await utils.getUnstakedDeposit(dontChallengeListing, registry);
+      const afterWithdrawDeposit = await registry.getListingUnstakedDeposit(dontChallengeListing);
 
       expect(afterWithdrawDeposit).to.be.bignumber.equal(origDeposit, errMsg);
     });

--- a/test/utils/contractutils.ts
+++ b/test/utils/contractutils.ts
@@ -103,21 +103,12 @@ export async function addToWhitelist(
   await registry.updateStatus(listingAddress, { from: account });
 }
 
-export function toBaseTenBigNumber(p: any): BigNumber {
+export function toBaseTenBigNumber(p: number): BigNumber {
   return new BigNumber(p.toString(10), 10);
 }
 
 export function getVoteSaltHash(vote: string, salt: string): string {
   return `0x${abi.soliditySHA3(["uint", "uint"], [vote, salt]).toString("hex")}`;
-}
-
-export async function getUnstakedDeposit(
-  listingAddress: string,
-  registry: any,
-): Promise<BigNumber> {
-  const listing = await registry.listings(listingAddress);
-  const unstakedDeposit = await listing[3];
-  return unstakedDeposit;
 }
 
 export async function commitVote( voting: any,

--- a/test/utils/contractutils.ts
+++ b/test/utils/contractutils.ts
@@ -60,14 +60,17 @@ export async function advanceEvmTime(time: number): Promise<void> {
   });
 }
 
-export async function proposeReparamAndGetPropID( propName: string,
-                                                  propValue: string,
-                                                  parameterizer: any,
-                                                  account: string,
-                                                ): Promise<any> {
-  const receipt = await parameterizer.proposeReparameterization(propName,
-                                                                propValue,
-                                                                { from: account });
+export async function proposeReparamAndGetPropID(
+  propName: string,
+  propValue: BigNumber,
+  parameterizer: any,
+  account: string,
+): Promise<any> {
+  const receipt = await parameterizer.proposeReparameterization(
+    propName,
+    propValue,
+    { from: account },
+  );
   return receipt.logs[0].args.propID;
 }
 
@@ -100,7 +103,7 @@ export async function addToWhitelist(
   await registry.updateStatus(listingAddress, { from: account });
 }
 
-export function toBaseTenBigNumber(p: number): BigNumber {
+export function toBaseTenBigNumber(p: any): BigNumber {
   return new BigNumber(p.toString(10), 10);
 }
 


### PR DESCRIPTION
Refactor contracts to change public mappings to structs to internal, with getter functions for data within. Updating unit tests.