### PR TITLE
Restricted Address Registries

### DIFF
--- a/contracts/AddressRegistry.sol
+++ b/contracts/AddressRegistry.sol
@@ -82,7 +82,7 @@ contract AddressRegistry {
     @param _amount      The number of ERC20 tokens a user is willing to potentially stake
     @param _data        Extra data relevant to the application. Think IPFS hashes.
     */
-    function apply(address _listingAddress, uint _amount, string _data) external {
+    function apply(address _listingAddress, uint _amount, string _data) public {
         require(!getListingIsWhitelisted(_listingAddress));
         require(!appWasMade(_listingAddress));
         require(_amount >= parameterizer.get("minDeposit"));

--- a/contracts/ContractAddressRegistry.sol
+++ b/contracts/ContractAddressRegistry.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.4.18;
+
+import "./AddressRegistry.sol";
+import "./ACL.sol";
+
+contract ContractAddressRegistry is AddressRegistry {
+
+  modifier onlyContract(address contractAddress) {
+    uint size;
+    assembly { size := extcodesize(contractAddress) }
+    require(size > 0);
+    _;
+  }
+
+  /**
+  @dev Contructor         Sets the addresses for token, voting, and parameterizer
+  @param _tokenAddr       Address of the TCR's intrinsic ERC20 token
+  @param _plcrAddr        Address of a PLCR voting contract for the provided token
+  @param _paramsAddr      Address of a Parameterizer contract 
+  */
+  function ContractAddressRegistry(
+      address _tokenAddr,
+      address _plcrAddr,
+      address _paramsAddr
+  ) public AddressRegistry(_tokenAddr, _plcrAddr, _paramsAddr) {
+      
+  }
+
+  // --------------------
+  // PUBLISHER INTERFACE:
+  // --------------------
+
+  /**
+  @dev                Allows a user to start an application. Takes tokens from user and sets
+                      apply stage end time.
+  @param _amount      The number of ERC20 tokens a user is willing to potentially stake
+  */
+  function apply(address _listingAddress, uint _amount, string _data) onlyContract(_listingAddress) public {
+    super.apply(_listingAddress, _amount, _data);
+  }
+}

--- a/contracts/PLCRVoting.sol
+++ b/contracts/PLCRVoting.sol
@@ -13,11 +13,11 @@ contract PLCRVoting {
     // EVENTS:
     // ============
 
-    event VoteCommitted(address voter, uint pollID, uint numTokens);
-    event VoteRevealed(address voter, uint pollID, uint numTokens, uint choice);
-    event PollCreated(uint voteQuorum, uint commitDuration, uint revealDuration, uint pollID);
-    event VotingRightsGranted(address voter, uint numTokens);
-    event VotingRightsWithdrawn(address voter, uint numTokens);
+    event VoteCommitted(address indexed voter, uint indexed pollID, uint numTokens);
+    event VoteRevealed(address indexed voter, uint indexed pollID, uint numTokens, uint choice);
+    event PollCreated(uint voteQuorum, uint commitDuration, uint revealDuration, uint indexed pollID);
+    event VotingRightsGranted(address indexed voter, uint numTokens);
+    event VotingRightsWithdrawn(address indexed voter, uint numTokens);
 
     // ============
     // DATA STRUCTURES:

--- a/contracts/Parameterizer.sol
+++ b/contracts/Parameterizer.sol
@@ -163,7 +163,7 @@ contract Parameterizer {
 
     challenges[pollID] = Challenge({
       challenger: msg.sender,
-      rewardPool: ((100 - get("pDispensationPct")) * deposit) / 100, 
+      rewardPool: ((100 - get("pDispensationPct")) * deposit) / 100,
       stake: deposit,
       resolved: false,
       winningTokens: 0

--- a/contracts/RestrictedAddressRegistry.sol
+++ b/contracts/RestrictedAddressRegistry.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.4.18;
+
+import "./ContractAddressRegistry.sol";
+import "./ACL.sol";
+
+contract RestrictedAddressRegistry is ContractAddressRegistry {
+
+  modifier onlySuperuser(address _sender, address _contractAddress) {
+    ACL aclContract = ACL(_contractAddress);
+    require(aclContract.isSuperuser(_sender));
+    _;
+  }
+
+  /**
+  @dev Contructor         Sets the addresses for token, voting, and parameterizer
+  @param _tokenAddr       Address of the TCR's intrinsic ERC20 token
+  @param _plcrAddr        Address of a PLCR voting contract for the provided token
+  @param _paramsAddr      Address of a Parameterizer contract 
+  */
+  function RestrictedAddressRegistry(
+      address _tokenAddr,
+      address _plcrAddr,
+      address _paramsAddr
+  ) public ContractAddressRegistry(_tokenAddr, _plcrAddr, _paramsAddr) {
+      
+  }
+
+  // --------------------
+  // PUBLISHER INTERFACE:
+  // --------------------
+
+  /**
+  @dev                Allows a user to start an application. Takes tokens from user and sets
+                      apply stage end time.
+  @param _amount      The number of ERC20 tokens a user is willing to potentially stake
+  */
+  function apply(address _listingAddress, uint _amount, string _data) onlySuperuser(msg.sender, _listingAddress) public {
+    super.apply(_listingAddress, _amount, _data);
+  }
+}

--- a/contracts/RestrictedAddressRegistry.sol
+++ b/contracts/RestrictedAddressRegistry.sol
@@ -1,13 +1,16 @@
 pragma solidity ^0.4.18;
 
 import "./ContractAddressRegistry.sol";
-import "./ACL.sol";
+
+interface IACL {
+  function isSuperuser(address user) public view returns (bool);
+}
 
 contract RestrictedAddressRegistry is ContractAddressRegistry {
 
-  modifier onlySuperuser(address _sender, address _contractAddress) {
-    ACL aclContract = ACL(_contractAddress);
-    require(aclContract.isSuperuser(_sender));
+  modifier onlySuperuser(address _contractAddress) {
+    IACL aclContract = IACL(_contractAddress);
+    require(aclContract.isSuperuser(msg.sender));
     _;
   }
 
@@ -34,7 +37,7 @@ contract RestrictedAddressRegistry is ContractAddressRegistry {
                       apply stage end time.
   @param _amount      The number of ERC20 tokens a user is willing to potentially stake
   */
-  function apply(address _listingAddress, uint _amount, string _data) onlySuperuser(msg.sender, _listingAddress) public {
+  function apply(address _listingAddress, uint _amount, string _data) onlySuperuser(_listingAddress) public {
     super.apply(_listingAddress, _amount, _data);
   }
 }

--- a/test/contractRegistry/apply.ts
+++ b/test/contractRegistry/apply.ts
@@ -22,7 +22,8 @@ contract("ContractAddressRegistry", (accounts) => {
     it("should allow contract owner to apply on behalf of contract", async () => {
       const testNewsroom = await Newsroom.new({ from: applicant });
       const address = testNewsroom.address;
-      await registry.apply(testNewsroom.address, utils.paramConfig.minDeposit, "", {from: applicant });
+      await expect(registry.apply(testNewsroom.address, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.fulfilled();
 
       // get the struct in the mapping
       const applicationExpiry = await registry.getListingApplicationExpiry(address);
@@ -75,7 +76,7 @@ contract("ContractAddressRegistry", (accounts) => {
       const testNewsroom = await Newsroom.new({ from: troll });
       const address = testNewsroom.address;
       await expect(registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant }))
-        .to.eventually.be.fulfilled;
+        .to.eventually.be.fulfilled();
     });
 
     it("should prevent non-contract address from being listed when registry cast to AddressRegistry", async () => {

--- a/test/contractRegistry/apply.ts
+++ b/test/contractRegistry/apply.ts
@@ -46,7 +46,7 @@ contract("ContractAddressRegistry", (accounts) => {
       const testNewsroom = await Newsroom.new({ from: applicant });
       const address = testNewsroom.address;
       await registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant });
-      await expect(registry.apply(address, utils.paramConfig.minDeposit, {from: applicant }))
+      await expect(registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant }))
         .to.eventually.be.rejectedWith(REVERTED);
     });
 

--- a/test/contractRegistry/apply.ts
+++ b/test/contractRegistry/apply.ts
@@ -1,0 +1,87 @@
+import * as chai from "chai";
+import { REVERTED } from "../../utils/constants";
+import ChaiConfig from "../utils/chaiconfig";
+import * as utils from "../utils/contractutils";
+
+ChaiConfig();
+const expect = chai.expect;
+
+const Newsroom = artifacts.require("Newsroom");
+const AddressRegistry = artifacts.require("AddressRegistry");
+
+contract("ContractAddressRegistry", (accounts) => {
+  describe("Function: apply", () => {
+    const [applicant, troll] = accounts;
+    const listing1 = "0x0000000000000000000000000000000000000001";
+    let registry: any;
+
+    beforeEach(async () => {
+      registry = await utils.createAllTestContractAddressRegistryInstance(accounts);
+    });
+
+    it("should allow contract owner to apply on behalf of contract", async () => {
+      const testNewsroom = await Newsroom.new({ from: applicant });
+      const address = testNewsroom.address;
+      await registry.apply(testNewsroom.address, utils.paramConfig.minDeposit, "", {from: applicant });
+
+      // get the struct in the mapping
+      const applicationExpiry = await registry.getListingApplicationExpiry(address);
+      const whitelisted = await registry.getListingIsWhitelisted(address);
+      const owner = await registry.getListingOwner(address);
+      const unstakedDeposit = await registry.getListingUnstakedDeposit(address);
+
+      // check that Application is initialized correctly
+      expect(applicationExpiry).to.be.bignumber.gt(0, "challenge time < now");
+      expect(whitelisted).to.be.false("whitelisted != false");
+      expect(owner).to.be.equal(applicant, "owner of application != address that applied");
+      expect(unstakedDeposit).to.be.bignumber.equal(utils.paramConfig.minDeposit, "incorrect unstakedDeposit");
+    });
+
+    it("should prevent non-contract address from being listed", async () => {
+      await expect(registry.apply(listing1, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+
+    it("should not allow a listing to apply which has a pending application", async () => {
+      const testNewsroom = await Newsroom.new({ from: applicant });
+      const address = testNewsroom.address;
+      await registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant });
+      await expect(registry.apply(address, utils.paramConfig.minDeposit, {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+
+    it(
+      "should add a listing to the whitelist which went unchallenged in its application period",
+      async () => {
+        const testNewsroom = await Newsroom.new({ from: applicant });
+        const address = testNewsroom.address;
+        await registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant });
+        await utils.advanceEvmTime(utils.paramConfig.applyStageLength + 1);
+        await registry.updateStatus(address);
+        const result = await registry.getListingIsWhitelisted(address);
+        expect(result).to.be.true("listing didn't get whitelisted");
+      },
+    );
+
+    it("should not allow a listing to apply which is already listed", async () => {
+      const testNewsroom = await Newsroom.new({ from: applicant });
+      const address = testNewsroom.address;
+      await utils.addToWhitelist(address, utils.paramConfig.minDeposit, applicant, registry);
+      await expect(registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+
+    it("should allow a non-contract owner to apply", async () => {
+      const testNewsroom = await Newsroom.new({ from: troll });
+      const address = testNewsroom.address;
+      await expect(registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.fulfilled;
+    });
+
+    it("should prevent non-contract address from being listed when registry cast to AddressRegistry", async () => {
+      const parentRegistry = await AddressRegistry.at(registry.address);
+      await expect(parentRegistry.apply(listing1, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+  });
+});

--- a/test/restrictedRegistry/apply.ts
+++ b/test/restrictedRegistry/apply.ts
@@ -47,7 +47,7 @@ contract("RestrictedAddressRegistry", (accounts) => {
       const testNewsroom = await Newsroom.new({ from: applicant });
       const address = testNewsroom.address;
       await registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant });
-      await expect(registry.apply(address, utils.paramConfig.minDeposit, {from: applicant }))
+      await expect(registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant }))
         .to.eventually.be.rejectedWith(REVERTED);
     });
 

--- a/test/restrictedRegistry/apply.ts
+++ b/test/restrictedRegistry/apply.ts
@@ -1,0 +1,97 @@
+import * as chai from "chai";
+import { REVERTED } from "../../utils/constants";
+import ChaiConfig from "../utils/chaiconfig";
+import * as utils from "../utils/contractutils";
+
+ChaiConfig();
+const expect = chai.expect;
+
+const Newsroom = artifacts.require("Newsroom");
+const AddressRegistry = artifacts.require("AddressRegistry");
+const ContractAddressRegistry = artifacts.require("ContractAddressRegistry");
+
+contract("RestrictedAddressRegistry", (accounts) => {
+  describe("Function: apply", () => {
+    const [applicant, troll] = accounts;
+    const listing1 = "0x0000000000000000000000000000000000000001";
+    let registry: any;
+
+    beforeEach(async () => {
+      registry = await utils.createAllTestRestrictedAddressRegistryInstance(accounts);
+    });
+
+    it("should allow contract owner to apply on behalf of contract", async () => {
+      const testNewsroom = await Newsroom.new({ from: applicant });
+      const address = testNewsroom.address;
+      await registry.apply(testNewsroom.address, utils.paramConfig.minDeposit, "", {from: applicant });
+
+      // get the struct in the mapping
+      const applicationExpiry = await registry.getListingApplicationExpiry(address);
+      const whitelisted = await registry.getListingIsWhitelisted(address);
+      const owner = await registry.getListingOwner(address);
+      const unstakedDeposit = await registry.getListingUnstakedDeposit(address);
+
+      // check that Application is initialized correctly
+      expect(applicationExpiry).to.be.bignumber.gt(0, "challenge time < now");
+      expect(whitelisted).to.be.false("whitelisted != false");
+      expect(owner).to.be.equal(applicant, "owner of application != address that applied");
+      expect(unstakedDeposit).to.be.bignumber.equal(utils.paramConfig.minDeposit, "incorrect unstakedDeposit");
+    });
+
+    it("should prevent non-contract address from being listed", async () => {
+      await expect(registry.apply(listing1, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+
+    it("should not allow a listing to apply which has a pending application", async () => {
+      const testNewsroom = await Newsroom.new({ from: applicant });
+      const address = testNewsroom.address;
+      await registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant });
+      await expect(registry.apply(address, utils.paramConfig.minDeposit, {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+
+    it(
+      "should add a listing to the whitelist which went unchallenged in its application period",
+      async () => {
+        const testNewsroom = await Newsroom.new({ from: applicant });
+        const address = testNewsroom.address;
+        await registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant });
+        await utils.advanceEvmTime(utils.paramConfig.applyStageLength + 1);
+        await registry.updateStatus(address);
+        const result = await registry.getListingIsWhitelisted(address);
+        expect(result).to.be.true("listing didn't get whitelisted");
+      },
+    );
+
+    it("should not allow a listing to apply which is already listed", async () => {
+      const testNewsroom = await Newsroom.new({ from: applicant });
+      const address = testNewsroom.address;
+      await utils.addToWhitelist(address, utils.paramConfig.minDeposit, applicant, registry);
+      await expect(registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+
+    it("should not allow a non-contract owner to apply", async () => {
+      const testNewsroom = await Newsroom.new({ from: troll });
+      const address = testNewsroom.address;
+      await expect(registry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+
+    it("should prevent non-contract address from being listed when registry cast to AddressRegistry", async () => {
+      const parentRegistry = await AddressRegistry.at(registry.address);
+      await expect(parentRegistry.apply(listing1, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+
+    it("should prevent un-owned address from being listed when registry cast to ContractAddressRegistry", async () => {
+      const testNewsroom = await Newsroom.new({ from: troll });
+      const address = testNewsroom.address;
+      const parentRegistry = await ContractAddressRegistry.at(registry.address);
+      await expect(parentRegistry.apply(address, utils.paramConfig.minDeposit, "", {from: applicant }))
+        .to.eventually.be.rejectedWith(REVERTED);
+    });
+
+  });
+});

--- a/test/utils/contractutils.ts
+++ b/test/utils/contractutils.ts
@@ -12,6 +12,8 @@ const Token = artifacts.require("tokens/eip20/EIP20");
 const PLCRVoting = artifacts.require("PLCRVoting");
 const Parameterizer = artifacts.require("Parameterizer");
 const AddressRegistry = artifacts.require("AddressRegistry");
+const RestrictedAddressRegistry = artifacts.require("RestrictedAddressRegistry");
+const ContractAddressRegistry = artifacts.require("ContractAddressRegistry");
 
 const config = JSON.parse(fs.readFileSync("./conf/config.json").toString());
 export const paramConfig = config.paramDefaults;
@@ -163,7 +165,11 @@ async function createAndDistributeToken(totalSupply: BigNumber,
   return token;
 }
 
-async function createTestAddressRegistryInstance(parameterizer: any, accounts: string[]): Promise<any> {
+async function createTestRegistryInstance(
+  registryContract: any,
+  parameterizer: any,
+  accounts: string[],
+): Promise<any> {
   async function approveRegistryFor(addresses: string[]): Promise<boolean> {
     const user = addresses[0];
     const balanceOfUser = await token.balanceOf(user);
@@ -177,7 +183,7 @@ async function createTestAddressRegistryInstance(parameterizer: any, accounts: s
   const parameterizerAddress = await parameterizer.address;
   const token = await Token.at(tokenAddress);
 
-  const registry = await AddressRegistry.new(tokenAddress, plcrAddress, parameterizerAddress);
+  const registry = await registryContract.new(tokenAddress, plcrAddress, parameterizerAddress);
 
   await approveRegistryFor(accounts);
   return registry;
@@ -241,8 +247,16 @@ export async function createAllTestParameterizerInstance(accounts: string[]): Pr
 }
 
 export async function createAllTestAddressRegistryInstance(accounts: string[]): Promise<any> {
-  const token = await createTestTokenInstance(accounts);
-  const plcr = await createTestPLCRInstance(token, accounts);
-  const parameterizer = await createTestParameterizerInstance(accounts, token, plcr);
-  return createTestAddressRegistryInstance(parameterizer, accounts);
+  const parameterizer = await createAllTestParameterizerInstance(accounts);
+  return createTestRegistryInstance(AddressRegistry, parameterizer, accounts);
+}
+
+export async function createAllTestRestrictedAddressRegistryInstance(accounts: string[]): Promise<any> {
+  const parameterizer = await createAllTestParameterizerInstance(accounts);
+  return createTestRegistryInstance(RestrictedAddressRegistry, parameterizer, accounts);
+}
+
+export async function createAllTestContractAddressRegistryInstance(accounts: string[]): Promise<any> {
+  const parameterizer = await createAllTestParameterizerInstance(accounts);
+  return createTestRegistryInstance(ContractAddressRegistry, parameterizer, accounts);
 }


### PR DESCRIPTION
- Creating two new registry contracts that extend AddressRegistry but add qualifications to what kind of addresses can apply (contracts, contracts in which sender is superuser). 
- Unit tests for applying to both of these new contracts. 
- Making some parameters of Parameterizer events indexed, so they're easier to work with.